### PR TITLE
Potential fix for code scanning alert no. 10: Uncontrolled data used in path expression

### DIFF
--- a/Vulstotal/VulsTotal.py
+++ b/Vulstotal/VulsTotal.py
@@ -36,6 +36,10 @@ reload(sys)
 sys.setdefaultencoding('utf8')
 
 def apk_name_handle(apks_folder):
+    safe_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'safe_apks'))
+    apks_folder = os.path.abspath(apks_folder)
+    if not apks_folder.startswith(safe_root):
+        raise Exception("Access to this directory is not allowed")
     apk_name = os.listdir(apks_folder)
     for i in reversed(range(len(apk_name))):
         if not ('.apk' in apk_name[i]):


### PR DESCRIPTION
Potential fix for [https://github.com/android-app-sast/VulsTotal/security/code-scanning/10](https://github.com/android-app-sast/VulsTotal/security/code-scanning/10)

To fix the problem, we need to validate the `apks_folder` path to ensure it does not lead to directory traversal attacks. We can achieve this by normalizing the path and ensuring it is contained within a predefined safe directory. This involves the following steps:
1. Define a safe root directory.
2. Normalize the user-provided path.
3. Check if the normalized path starts with the safe root directory.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
